### PR TITLE
Fix zone_id, prepare v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v1.1.0
+
+- [Fix Zone ID](https://github.com/babbel/terraform-aws-ses-sending-domain/pull/2)
+
 ## v1.0.0
 
 - [Initial version](https://github.com/babbel/terraform-aws-ses-sending-domain/pull/1)

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -3,7 +3,7 @@ module "ses-sending-domain" {
 
   domain_name = "example.com"
   route53_zone = {
-    id = "123"
+    zone_id = "123"
   }
   sns_topic_name = "foo"
   tags           = {}

--- a/dkim.tf
+++ b/dkim.tf
@@ -7,7 +7,7 @@ resource "aws_ses_domain_dkim" "this" {
 resource "aws_route53_record" "domainkey_cname" {
   count = 3
 
-  zone_id = var.route53_zone.id
+  zone_id = var.route53_zone.zone_id
   name    = "${aws_ses_domain_dkim.this.dkim_tokens[count.index]}._domainkey.${var.domain_name}."
   type    = "CNAME"
   ttl     = 3600

--- a/ses.tf
+++ b/ses.tf
@@ -3,7 +3,7 @@ resource "aws_ses_domain_identity" "this" {
 }
 
 resource "aws_route53_record" "amazonses_txt" {
-  zone_id = var.route53_zone.id
+  zone_id = var.route53_zone.zone_id
   name    = "_amazonses.${var.domain_name}."
   type    = "TXT"
   ttl     = 600

--- a/spf.tf
+++ b/spf.tf
@@ -1,5 +1,5 @@
 resource "aws_route53_record" "txt" {
-  zone_id = var.route53_zone.id
+  zone_id = var.route53_zone.zone_id
   name    = "${var.domain_name}."
   type    = "TXT"
   ttl     = 600

--- a/variables.tf
+++ b/variables.tf
@@ -7,7 +7,7 @@ EOS
 }
 
 variable "route53_zone" {
-  type = object({ id = string })
+  type = object({ zone_id = string })
 
   description = <<EOS
 The Route53 hosted zone to which all DNS records shall be added.


### PR DESCRIPTION
Terraform resource [`aws_route53_zone`](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_zone) has an attribute `zone_id`, not `id`.