### PR TITLE
Add support for resource-specific tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,5 @@ module "ses-sending-domain-example" {
   domain_name    = "example.com"
   route53_zone   = aws_route53_zone.email-example
   sns_topic_name = "example"
-
-  tags = {
-    environment = "production"
-  }
 }
 ```

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -10,5 +10,9 @@ module "ses-sending-domain" {
     zone_id = "123"
   }
   sns_topic_name = "foo"
-  tags           = {}
+
+  default_tags = {
+    app = "example"
+    env = "test"
+  }
 }

--- a/notifications.tf
+++ b/notifications.tf
@@ -1,6 +1,6 @@
 resource "aws_sns_topic" "this" {
   name = var.sns_topic_name
-  tags = var.tags
+  tags = merge(var.default_tags, var.sns_topic_tags)
 }
 
 resource "aws_ses_identity_notification_topic" "bounce" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,12 @@
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
 variable "domain_name" {
   type = string
 
@@ -20,15 +29,15 @@ variable "sns_topic_name" {
   type = string
 
   description = <<EOS
-Name of SNS topic
+Name of SNS topic.
 EOS
 }
 
-variable "tags" {
+variable "sns_topic_tags" {
   type    = map(string)
   default = {}
 
   description = <<EOS
-Tags which will be attached to all resources.
+Map of tags assigned to the SNS topic. These tags will be merged with `var.default_tags`.
 EOS
 }


### PR DESCRIPTION
Breaking change: Renaming `var.tags` to `var.default_tag` in order to make it clearer that those are tags are applied to all AWS resources.