### PR TITLE
Breaking change: Rename `var.tags` to `var.default_tags`

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,5 @@ module "ses-sending-domain-example" {
   domain_name    = "example.com"
   route53_zone   = aws_route53_zone.email-example
   sns_topic_name = "example"
-
-  tags = {
-    environment = "production"
-  }
 }
 ```

--- a/_test/main.tf
+++ b/_test/main.tf
@@ -10,5 +10,9 @@ module "ses-sending-domain" {
     zone_id = "123"
   }
   sns_topic_name = "foo"
-  tags           = {}
+
+  default_tags = {
+    app = "example"
+    env = "test"
+  }
 }

--- a/notifications.tf
+++ b/notifications.tf
@@ -1,6 +1,6 @@
 resource "aws_sns_topic" "this" {
   name = var.sns_topic_name
-  tags = var.tags
+  tags = var.default_tags
 }
 
 resource "aws_ses_identity_notification_topic" "bounce" {

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,12 @@
+variable "default_tags" {
+  type    = map(string)
+  default = {}
+
+  description = <<EOS
+Map of tags assigned to all AWS resources created by this module.
+EOS
+}
+
 variable "domain_name" {
   type = string
 
@@ -23,14 +32,5 @@ variable "sns_topic_name" {
 
   description = <<EOS
 Name of SNS topic.
-EOS
-}
-
-variable "tags" {
-  type    = map(string)
-  default = {}
-
-  description = <<EOS
-Map of tags assigned to all AWS resources created by this module.
 EOS
 }


### PR DESCRIPTION
This change is done to make it more clear, that tags specified via this attribute will be assigned to all AWS resources created by this module.

Also drop this attribute from the usage example in the `README.md`, as this attribute is rather for edge cases, as default tags typically specified via the `default_tags` block of the AWS provider.