### PR TITLE
Add option to disable SPF TXT record

### DIFF
--- a/spf.tf
+++ b/spf.tf
@@ -1,4 +1,6 @@
 resource "aws_route53_record" "txt" {
+  count = var.configure_spf ? 1 : 0
+
   zone_id = var.route53_zone.zone_id
   name    = "${var.domain_name}."
   type    = "TXT"

--- a/variables.tf
+++ b/variables.tf
@@ -1,3 +1,12 @@
+variable "configure_spf" {
+  type    = bool
+  default = true
+
+  description = <<EOS
+Whether to configure SPF record for the domain.
+EOS
+}
+
 variable "default_tags" {
   type    = map(string)
   default = {}


### PR DESCRIPTION
Adding `configure_spf` variable to allow disabling the SPF TXT record. This way the TXT record can be managed outside of the module.

This change will re-create the TXT record as it now is using `count`